### PR TITLE
Fixed Crash in Utils

### DIFF
--- a/src/DaPigGuy/PiggyAuctions/utils/Utils.php
+++ b/src/DaPigGuy/PiggyAuctions/utils/Utils.php
@@ -18,9 +18,10 @@ class Utils
 
     public static function formatDetailedDuration(int $duration): string
     {
+        $duration = round($duration);
         $days = floor($duration / 86400);
-        $hours = floor($duration / 3600 % 24);
-        $minutes = floor($duration / 60 % 60);
+        $hours = floor(($duration % 86400) / 3600);
+        $minutes = floor(($duration % 3600) / 60);
         $seconds = floor($duration % 60);
 
         if ($days >= 1) {


### PR DESCRIPTION
Server Getting Crashed on Line 22-23 For Implicit conversion from float to int loses precision

CRASHDUMP LOOK:
Error: Implicit conversion from float 12744.516666666666 to int loses precision File: plugins/PiggyAuctions-master/src/DaPigGuy/PiggyAuctions/utils/Utils

12744.516666666666 CAN BE ANY OTHER NUMBER.

<!-- Failure to complete the required fields will result in the pull request being closed. -->
Please make sure your issue complies with these guidelines:
- * [x] Use same formatting
- * [x] Changes must have been tested on PMMP.
- * [x] Unless it is a minor code modification, you must use an IDE.
- * [x] Have a detailed title.

### What does the PR change?

- resolve a bug


### Testing Environment
<!-- Use `/version` for PMMP version -->
* PocketMine-MP: 4.23.6 [Protocol 594]
* PHP: 8.1.22
* Server OS: Linux

<!--- Provide any extra information below  -->
### Extra Information
